### PR TITLE
only overwrite headers with TOC if the TOC-readout worked for one

### DIFF
--- a/hierarchical/postprocessor.py
+++ b/hierarchical/postprocessor.py
@@ -132,7 +132,8 @@ class ResultPostprocessor:
         header_correction = False
         if len(hbm.toc) > 0:
             root = hbm.infer()
-            header_correction = True
+            if root.children:
+                header_correction = True
         else:
             headings = self.get_headers()
             root = create_toc(headings)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -20,6 +20,17 @@ def compare(res_text, fn):
         p.write_text(res_text)
 
 
+@pytest.mark.skip(reason="runs too long for circleci.")
+def test_nfl():
+    source = sample_path / "2025-nfl-rulebook-final.pdf"  # document per local path or URL
+    converter = DocumentConverter()
+    result = converter.convert(source)
+    ResultPostprocessor(result).process()
+
+    headers = ResultPostprocessor(result)._get_headers_document()
+    assert len(headers) > 0
+
+
 def test_result_postprocessor_textpdf_no_bookmarks():
     source = sample_path / "sample_document_no_bookmarks.pdf"  # document per local path or URL
     converter = DocumentConverter()


### PR DESCRIPTION
only overwrite headers with TOC if the TOC-readout gave at least one heading hit with text in the PDF.

fixes https://github.com/krrome/docling-hierarchical-pdf/issues/14