### PR TITLE
Fix range iteration for page handling

### DIFF
--- a/hierarchical/hierarchy_builder_metadata.py
+++ b/hierarchical/hierarchy_builder_metadata.py
@@ -114,7 +114,10 @@ class HierarchyBuilderMetadata:
                         add_info["coords"] = this_bbox
                     # sometimes the bookmark still points to the previous page, but the header is at the top of the current page
                     # future todo - instead of this try to use the offset of the bookmark pointer!
-                    for page_here in range(page, min(page + 1, page_count) + 1):
+                    pages = [page]
+                    if page + 1 <= page_count:
+                        pages += [page + 1]
+                    for page_here in pages:
                         if "coords" not in add_info:
                             title_ref = re.sub(r"[^A-Za-z0-9]", "", title)
                             actual_title = ""

--- a/hierarchical/hierarchy_builder_metadata.py
+++ b/hierarchical/hierarchy_builder_metadata.py
@@ -90,6 +90,7 @@ class HierarchyBuilderMetadata:
         try:
             with self._get_source_kwargs() as kwargs:
                 doc = FitzDocument(**kwargs)
+                page_count = len(doc)
                 toc = doc.get_toc(  # type: ignore[attr-defined]
                     simple=False
                 )  # gives a list of lists [<hierarchy level>, <Header name>, <pdf-page number>, <dict of additional information including position of the bookmark>]

--- a/hierarchical/hierarchy_builder_metadata.py
+++ b/hierarchical/hierarchy_builder_metadata.py
@@ -113,7 +113,7 @@ class HierarchyBuilderMetadata:
                         add_info["coords"] = this_bbox
                     # sometimes the bookmark still points to the previous page, but the header is at the top of the current page
                     # future todo - instead of this try to use the offset of the bookmark pointer!
-                    for page_here in [page, page + 1]:
+                    for page_here in range(page, min(page + 1, page_count) + 1):
                         if "coords" not in add_info:
                             title_ref = re.sub(r"[^A-Za-z0-9]", "", title)
                             actual_title = ""

--- a/tests/test_metadata_toc_page_bounds.py
+++ b/tests/test_metadata_toc_page_bounds.py
@@ -1,0 +1,43 @@
+from io import BytesIO
+from types import SimpleNamespace
+
+import hierarchical.hierarchy_builder_metadata as hierarchy_builder_metadata
+
+
+def test_extract_toc_handles_last_page_without_overflow(monkeypatch):
+    class FakeTextPage:
+        @staticmethod
+        def extractBLOCKS():
+            return []
+
+    class FakePage:
+        @staticmethod
+        def search_for(_title):
+            return []
+
+        @staticmethod
+        def get_textpage():
+            return FakeTextPage()
+
+    class FakeDoc:
+        def __init__(self, **_kwargs):
+            self.pages = [FakePage(), FakePage()]
+
+        def __len__(self):
+            return len(self.pages)
+
+        def __getitem__(self, index):
+            if index < 0 or index >= len(self.pages):
+                raise AssertionError(f"Unexpected page access: {index}")
+            return self.pages[index]
+
+        @staticmethod
+        def get_toc(simple=False):
+            assert simple is False
+            return [[1, "Last section", 2, {}]]
+
+    monkeypatch.setattr(hierarchy_builder_metadata, "FitzDocument", FakeDoc)
+    conv_res = SimpleNamespace(input=SimpleNamespace(file="pdf"))
+    hbm = hierarchy_builder_metadata.HierarchyBuilderMetadata(conv_res, source=BytesIO(b"%PDF-1.4"))
+
+    assert hbm.toc == [(1, "Last section", 2, {})]

--- a/tests/test_metadata_toc_page_bounds.py
+++ b/tests/test_metadata_toc_page_bounds.py
@@ -28,7 +28,7 @@ def test_extract_toc_handles_last_page_without_overflow(monkeypatch):
 
         def __getitem__(self, index):
             if index < 0 or index >= len(self.pages):
-                raise AssertionError(f"Unexpected page access: {index}")
+                raise AssertionError(f"Unexpected page access: {index}")  # noqa: TRY003
             return self.pages[index]
 
         @staticmethod


### PR DESCRIPTION
There is a bug that tries to access the index of a page that doesn’t exist, which results in an error indicating that the page is missing. The solution is very simple: check the maximum number of pages and avoid trying to access more than the document actually contains.